### PR TITLE
feature: ability to run console or file based output on different environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Git Refs
+# Logger
 [![Build Status][ci-badge]][ci-badge-link]
 [![Dependency Status][david-badge]][david-badge-link]
 [![devDependency Status][david-dev-badge]][david-dev-badge-link]
@@ -16,11 +16,20 @@ npm install @sinet/logger --save
 // Options are for winston transports, file and console
 var options = {
 	'file' : {
+		// File transport is enabled on development and production environment
+		'enabled'  : [ 'development', 'production' ],
 		'filename' : 'logs/myLogFile.log',
 	},
 
 	'console' : {
-		'level' : 'debug'
+		// Console transport is enabled only in development environment
+		'enabled' : [ 'development' ],
+		'level'   : 'debug'
+	},
+
+	'logstash' : {
+		'enabled' : [ 'production' ],
+		'port'    : 9563
 	},
 
 	// These are additional fields that get added to all logs
@@ -37,6 +46,21 @@ var logger = require( '@sinet/logger' )( options );
 
 logger.error( 'error message', { 'method': 'v1.users.get', 'payload', payload } );
 ```
+
+## FAQs
+
+1. What happens when I add a `file` or `console` option without setting the `enabled` property?
+```javascript
+// Example
+var options = {
+	'file'    : {},
+	'console' : {}
+}
+```
+
+Answer:
+If `file` and/or `console` is explicitly provided without setting the enabled property it will log in any environment.
+
 
 ## Contributing
 All pull requests must follow [coding conventions and standards](https://github.com/School-Improvement-Network/coding-conventions).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinet/logger",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Default logger setup using Winston",
   "main": "index.js",
   "scripts": {
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "winston": "^1.0.1"
+    "winston": "^1.0.1",
+    "winston-logstash": "^0.2.11"
   }
 }

--- a/test/logging.js
+++ b/test/logging.js
@@ -2,11 +2,9 @@
 
 /* eslint no-underscore-dangle:0 */
 
-var rewire     = require( 'rewire' );
-var should     = require( 'should' );
-var os         = require( 'os' );
-
-require( 'should' );
+var rewire = require( 'rewire' );
+var should = require( 'should' );
+var os     = require( 'os' );
 
 describe( 'Additional fields', function () {
 	var hostname = os.hostname();

--- a/test/singleton.js
+++ b/test/singleton.js
@@ -36,7 +36,6 @@ describe( 'Require singleton', function () {
 
 	it( 'should provide singleton with original config', function () {
 		logger.transports.file.filename.should.be.of.type( 'string' ).and.equal( 'logs.log' );
-		logger.transports.file.level.should.be.of.type( 'string' ).and.equal( 'error' );
 		logger.transports.file.logstash.should.be.of.type( 'boolean' ).and.equal( true );
 		logger.transports.file.maxsize.should.be.of.type( 'number' ).and.equal( 15000000 );
 		logger.transports.file.tailable.should.be.of.type( 'boolean' ).and.equal( false );


### PR DESCRIPTION
@openam Can you review?

The `config` format I shown to you last time in flowdock gets too complicated.
Instead, I decided to just add an `enabled` property for `file` and `console` config option so we can control which will be `enabled` on specific environments.

```javascript
'file' : {
	// File transport is enabled on development and production environment
	'enabled'  : [ 'development', 'production' ],
	'filename' : 'logs/myLogFile.log',
},

'console' : {
	// Console transport is enabled only in development environment
	'enabled' : [ 'development' ],
	'level'   : 'debug'
},
```

If `enabled` is not set or is undefined, the transport log will run in any environment.
If it is set to an empty array, it won't run in any environment.